### PR TITLE
fix: save filename filter

### DIFF
--- a/src/napari_roi_manager/widgets/_roi_manager.py
+++ b/src/napari_roi_manager/widgets/_roi_manager.py
@@ -240,7 +240,7 @@ class QRoiManager(QtW.QWidget):
             file = QtW.QFileDialog.getOpenFileName(
                 self,
                 "Open ROIs",
-                filter="JSON (*.json; *.txt);;All Files (*)",
+                filter="JSON (*.json);;Text (*.txt);;All Files (*)",
             )
             if file:
                 path = file[0]
@@ -269,7 +269,7 @@ class QRoiManager(QtW.QWidget):
             file = QtW.QFileDialog.getSaveFileName(
                 self,
                 "Save ROIs",
-                filter="JSON (*.json; *.txt);;All Files (*)",
+                filter="JSON (*.json);;Text (*.txt);;All Files (*)",
             )
             if file:
                 path = file[0]


### PR DESCRIPTION
This change to the filename filter eliminates the addition of the extra semicolon at the end of `.json` files.

Suggested fix for #4 