### PR TITLE
Add a shortcut to Add button, matching ImageJ/Fiji ROI manager.

### DIFF
--- a/src/napari_roi_manager/widgets/_roi_manager.py
+++ b/src/napari_roi_manager/widgets/_roi_manager.py
@@ -176,6 +176,10 @@ class QRoiManager(QtW.QWidget):
         def _show_all_changed(state):
             layer.show_all = btns._show_all_checkbox.isChecked()
 
+        @layer.bind_key('t')
+        def _add_roi(layer):
+            layer.register_roi()
+
         @layer.events.roi_added.connect
         def _roi_added(event):
             tp = event.shape_type


### PR DESCRIPTION
ImageJ/Fiji ROI manager has the key `t` bound to add an ROi. This adds a layer key binding for `t` to do the same.